### PR TITLE
Fix test failures, Sentry session leak, admin email recipient

### DIFF
--- a/mandarin/ai/experiment_ai.py
+++ b/mandarin/ai/experiment_ai.py
@@ -603,7 +603,10 @@ def propose_ai_hypotheses(conn: sqlite3.Connection) -> list[dict]:
             ).fetchone()
             if existing_proposal:
                 continue
+        except sqlite3.OperationalError:
+            continue
 
+        try:
             existing_queue = conn.execute(
                 """SELECT id FROM experiment_approval_queue
                    WHERE experiment_name = ? AND status = 'pending'""",
@@ -612,7 +615,7 @@ def propose_ai_hypotheses(conn: sqlite3.Connection) -> list[dict]:
             if existing_queue:
                 continue
         except sqlite3.OperationalError:
-            continue
+            pass  # Table may not exist yet; proceed with submission
 
         # Create proposal record
         datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")

--- a/mandarin/db/core.py
+++ b/mandarin/db/core.py
@@ -83,7 +83,7 @@ class connection:
         return False
 
 
-SCHEMA_VERSION = 120  # Increment when adding migrations
+SCHEMA_VERSION = 121  # Increment when adding migrations
 
 
 def _get_schema_version(conn: sqlite3.Connection) -> int:
@@ -7246,6 +7246,28 @@ def _migrate_v119_to_v120(conn):
     conn.commit()
 
 
+def _migrate_v120_to_v121(conn):
+    """v120->v121: Add experiment_approval_queue for governance of AI-proposed experiments."""
+    tables = _table_set(conn)
+    if "experiment_approval_queue" not in tables:
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS experiment_approval_queue (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                action_type TEXT NOT NULL,
+                experiment_name TEXT NOT NULL,
+                proposed_by TEXT NOT NULL DEFAULT 'daemon',
+                proposal_data TEXT,
+                status TEXT NOT NULL DEFAULT 'pending',
+                reviewed_by TEXT,
+                reviewed_at TEXT,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            CREATE INDEX IF NOT EXISTS idx_approval_queue_status
+                ON experiment_approval_queue(status);
+        """)
+    conn.commit()
+
+
 MIGRATIONS = {
     0: _migrate_v0_to_v1,
     1: _migrate_v1_to_v2,
@@ -7367,6 +7389,7 @@ MIGRATIONS = {
     117: _migrate_v117_to_v118,
     118: _migrate_v118_to_v119,
     119: _migrate_v119_to_v120,
+    120: _migrate_v120_to_v121,
 }
 
 

--- a/mandarin/email.py
+++ b/mandarin/email.py
@@ -9,7 +9,7 @@ import logging
 
 import requests
 
-from .settings import RESEND_API_KEY, FROM_EMAIL, BASE_URL, MAILING_ADDRESS
+from .settings import RESEND_API_KEY, FROM_EMAIL, BASE_URL, MAILING_ADDRESS, ADMIN_EMAIL
 
 logger = logging.getLogger(__name__)
 
@@ -783,7 +783,7 @@ def send_daily_intelligence_digest(conn) -> bool:
     subject = f"Intelligence digest: {', '.join(parts)}"
 
     html = _wrap_html("Intelligence Digest", body_html)
-    return _send(FROM_EMAIL, subject, html)
+    return _send(ADMIN_EMAIL or FROM_EMAIL, subject, html)
 
 
 def _esc(text: str) -> str:

--- a/mandarin/experiment_governance.py
+++ b/mandarin/experiment_governance.py
@@ -1,0 +1,39 @@
+"""Experiment governance — approval queue for autonomous experiment actions.
+
+All AI-proposed experiment actions (start, conclude, rollout) must pass through
+this approval queue. Humans review; AI proposes.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+
+logger = logging.getLogger(__name__)
+
+
+def queue_for_approval(
+    conn: sqlite3.Connection,
+    action_type: str,
+    experiment_name: str,
+    proposal_data: dict,
+    proposed_by: str = "daemon",
+) -> int | None:
+    """Insert an action into the experiment_approval_queue for human review.
+
+    Returns the row id on success, None on failure.
+    """
+    try:
+        cur = conn.execute(
+            """INSERT INTO experiment_approval_queue
+               (action_type, experiment_name, proposed_by, proposal_data, status)
+               VALUES (?, ?, ?, ?, 'pending')""",
+            (action_type, experiment_name, proposed_by, json.dumps(proposal_data)),
+        )
+        conn.commit()
+        return cur.lastrowid
+    except sqlite3.OperationalError:
+        logger.warning(
+            "experiment_approval_queue table not found — skipping governance queue"
+        )
+        return None

--- a/mandarin/web/openclaw_routes.py
+++ b/mandarin/web/openclaw_routes.py
@@ -182,10 +182,13 @@ def notify():
 
             async def _send_telegram():
                 bot = Bot(token=OPENCLAW_TELEGRAM_TOKEN)
-                await bot.send_message(
-                    chat_id=security.OWNER_CHAT_ID, text=safe_message,
-                )
-                return True
+                try:
+                    await bot.send_message(
+                        chat_id=security.OWNER_CHAT_ID, text=safe_message,
+                    )
+                    return True
+                finally:
+                    await bot.shutdown()
 
             ok = asyncio.run(_send_telegram())
             if ok:

--- a/tests/test_local_llm.py
+++ b/tests/test_local_llm.py
@@ -70,7 +70,8 @@ def conn():
                 review_decision IN ('approved', 'rejected', 'edited')
             ),
             edited_content_json TEXT,
-            review_notes TEXT
+            review_notes TEXT,
+            provenance_checked INTEGER DEFAULT 0
         );
 
         CREATE TABLE vocab_encounter (
@@ -95,6 +96,8 @@ def conn():
             hsk_level INTEGER DEFAULT 1,
             status TEXT DEFAULT 'drill_ready',
             review_status TEXT DEFAULT 'approved',
+            is_ai_generated INTEGER DEFAULT 0,
+            generated_by_prompt TEXT,
             source TEXT,
             example_sentence_hanzi TEXT,
             example_sentence_pinyin TEXT,


### PR DESCRIPTION
## Summary
- Fix `test_review_queue_on_validation_failure`: sync test fixture schema with production (missing `is_ai_generated`, `generated_by_prompt` columns)
- Fix `test_submits_to_governance_queue`: create `experiment_governance` module, add `experiment_approval_queue` table (migration v121), fix error handling in `experiment_ai.py`
- Fix Sentry "Unclosed client session": properly `shutdown()` Telegram Bot after sending notifications
- Fix daily intelligence digest: send to `ADMIN_EMAIL` instead of `FROM_EMAIL` (noreply address)

## Test plan
- [x] `test_review_queue_on_validation_failure` passes
- [x] `test_submits_to_governance_queue` passes
- [ ] Verify Sentry errors stop after deploy
- [ ] Verify admin receives daily intelligence digest email

🤖 Generated with [Claude Code](https://claude.com/claude-code)