### PR TITLE
Exempt health check endpoints from rate limiting

### DIFF
--- a/mandarin/web/__init__.py
+++ b/mandarin/web/__init__.py
@@ -347,6 +347,12 @@ def create_app(testing=False):
     from .routes import register_routes
     register_routes(app)
 
+    # Exempt health check endpoints from rate limiting — Fly.io probes
+    # every 15s (240/hour) which exceeds the default 200/hour limit.
+    for ep in ("api_health_live", "api_health_ready"):
+        if ep in app.view_functions:
+            limiter.exempt(app.view_functions[ep])
+
     from .session_routes import register_session_routes
     register_session_routes(app)
 


### PR DESCRIPTION
## Summary
- Exempt `/api/health/live` and `/api/health/ready` from Flask-Limiter's default 200/hour rate limit
- Fly.io probes every 15s (240/hour), which was causing 429 responses and health check failures

## Test plan
- [ ] Verify health checks no longer return 429 after deploy
- [ ] Monitor logs for rate_limit_hit events on health endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)