### PR TITLE
Fix Sentry session leak, health check 429s, digest logging

### DIFF
--- a/mandarin/ai/audio_coherence.py
+++ b/mandarin/ai/audio_coherence.py
@@ -184,6 +184,7 @@ def _generate_tts(text: str) -> str | None:
     import asyncio
 
     async def _gen():
+        communicate = None
         try:
             import edge_tts
             tmp = tempfile.NamedTemporaryFile(suffix=".mp3", delete=False)
@@ -194,16 +195,36 @@ def _generate_tts(text: str) -> str | None:
         except Exception as e:
             logger.warning("TTS generation failed: %s", e)
             return None
+        finally:
+            if communicate is not None:
+                for attr in ("session", "_session"):
+                    sess = getattr(communicate, attr, None)
+                    if sess is not None and hasattr(sess, "close"):
+                        try:
+                            await sess.close()
+                        except Exception:
+                            pass
+
+    def _run_in_fresh_loop():
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(_gen())
+        finally:
+            try:
+                loop.run_until_complete(loop.shutdown_asyncgens())
+            except Exception:
+                pass
+            loop.close()
 
     try:
         loop = asyncio.get_event_loop()
         if loop.is_running():
             import concurrent.futures
             with concurrent.futures.ThreadPoolExecutor() as pool:
-                return pool.submit(lambda: asyncio.run(_gen())).result(timeout=30)
-        return loop.run_until_complete(_gen())
+                return pool.submit(_run_in_fresh_loop).result(timeout=30)
+        return _run_in_fresh_loop()
     except RuntimeError:
-        return asyncio.run(_gen())
+        return _run_in_fresh_loop()
 
 
 def _create_failure_work_item(

--- a/mandarin/intelligence/dependency_monitor.py
+++ b/mandarin/intelligence/dependency_monitor.py
@@ -258,20 +258,46 @@ def _check_tts() -> tuple[str, int, str | None]:
                         return True
                 return False
             finally:
-                # Close aiohttp session to prevent resource leaks
-                if hasattr(communicate, 'session') and communicate.session:
-                    await communicate.session.close()
+                # Close internal aiohttp session to prevent "Unclosed client session"
+                # errors. edge_tts stores the session in different attributes depending
+                # on version; try all known locations.
+                for attr in ("session", "_session", "ws", "_ws"):
+                    sess = getattr(communicate, attr, None)
+                    if sess is not None and hasattr(sess, "close"):
+                        try:
+                            await sess.close()
+                        except Exception:
+                            pass
+                # Give the event loop a tick to finalize any pending callbacks
+                await asyncio.sleep(0)
+
+        def _run_in_fresh_loop():
+            loop = asyncio.new_event_loop()
+            try:
+                return loop.run_until_complete(_test())
+            finally:
+                # Properly shut down to avoid "Task was destroyed" warnings
+                try:
+                    pending = asyncio.all_tasks(loop)
+                    for task in pending:
+                        task.cancel()
+                    if pending:
+                        loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+                except Exception:
+                    pass
+                loop.run_until_complete(loop.shutdown_asyncgens())
+                loop.close()
 
         try:
             loop = asyncio.get_event_loop()
             if loop.is_running():
                 import concurrent.futures
                 with concurrent.futures.ThreadPoolExecutor() as pool:
-                    result = pool.submit(lambda: asyncio.run(_test())).result(timeout=10)
+                    result = pool.submit(_run_in_fresh_loop).result(timeout=10)
             else:
-                result = asyncio.run(_test())
+                result = _run_in_fresh_loop()
         except RuntimeError:
-            result = asyncio.run(_test())
+            result = _run_in_fresh_loop()
 
         latency_ms = int((time.monotonic() - start) * 1000)
 

--- a/mandarin/web/__init__.py
+++ b/mandarin/web/__init__.py
@@ -349,9 +349,16 @@ def create_app(testing=False):
 
     # Exempt health check endpoints from rate limiting — Fly.io probes
     # every 15s (240/hour) which exceeds the default 200/hour limit.
-    for ep in ("api_health_live", "api_health_ready"):
+    # Also exempt the full /api/health endpoint.
+    for ep in ("api_health_live", "api_health_ready", "api_health"):
         if ep in app.view_functions:
             limiter.exempt(app.view_functions[ep])
+
+    # Belt-and-suspenders: also raise limit on health paths via decorator
+    # in case exempt() doesn't stick with custom storage backends.
+    for ep in ("api_health_live", "api_health_ready", "api_health"):
+        if ep in app.view_functions:
+            limiter.limit("2000/hour")(app.view_functions[ep])
 
     from .session_routes import register_session_routes
     register_session_routes(app)

--- a/mandarin/web/quality_scheduler.py
+++ b/mandarin/web/quality_scheduler.py
@@ -785,7 +785,7 @@ def _run_intelligence_loop():
                 from ..email import send_daily_intelligence_digest
                 send_daily_intelligence_digest(conn)
             except Exception:
-                logger.debug("Intelligence loop: daily digest email failed", exc_info=True)
+                logger.warning("Intelligence loop: daily digest email failed", exc_info=True)
 
     except Exception:
         logger.exception("Intelligence automation loop failed")


### PR DESCRIPTION
## Summary
- **aiohttp session leak**: Properly close edge_tts internal aiohttp sessions and shut down event loops in dependency_monitor and audio_coherence — fixes "Unclosed client session" and "Task was destroyed" Sentry errors on /api/health/ready
- **Health check rate limiting**: Add fallback 2000/hr explicit limit on health endpoints in case `limiter.exempt()` doesn't persist with custom SQLite storage backend (Fly probes at 240/hr were hitting the 200/hr default)
- **Digest email logging**: Raise daily intelligence digest failure from `debug` to `warning` so failures are visible in production logs (was silently swallowing Resend failures)

## Test plan
- [ ] Verify health check no longer returns 429 after deploy
- [ ] Verify Sentry "Unclosed client session" errors stop
- [ ] Check production logs for digest email warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)