### PR TITLE
Revert Dockerfile to Python 3.12 — fix deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim AS base
+FROM python:3.12-slim AS base
 
 # Install litestream for SQLite replication
 ARG LITESTREAM_VERSION=0.3.13


### PR DESCRIPTION
## Summary
- Reverts Docker base image from 3.14 to 3.12
- numba (librosa dep) has no Python 3.14 Linux wheels — Docker build fails on remote builder
- Local dev stays on 3.14 (macOS has wheels via Homebrew); production stays on 3.12

## Test plan
- [x] `fly deploy --depot=false` should now succeed
- Local dev/tests unaffected (still py3.14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)