### PR TITLE
Fix E2E registration, forward ref, and deploy

### DIFF
--- a/mandarin/ai/workflow_engine.py
+++ b/mandarin/ai/workflow_engine.py
@@ -43,7 +43,7 @@ class DurableWorkflow:
         name: str,
         fn: Callable,
         rollback_fn: Callable | None = None,
-    ) -> DurableWorkflow:
+    ) -> "DurableWorkflow":  # noqa: UP037 — forward ref needed on Python <3.14
         """Add a step to the workflow. Returns self for chaining."""
         self._steps.append({
             "name": name,

--- a/tests/e2e/test_golden_paths.py
+++ b/tests/e2e/test_golden_paths.py
@@ -33,6 +33,7 @@ def _register(page: Page, base_url: str, email: str = None):
     page.goto(f"{base_url}/auth/register")
     page.fill('input[name="email"]', email)
     page.fill('input[name="password"]', password)
+    page.fill('input[name="confirm"]', password)
     # Fill invite code if field exists (production mode)
     invite_field = page.locator('input[name="invite_code"]')
     if invite_field.count() > 0 and invite_field.is_visible():

--- a/tests/e2e/test_mobile.py
+++ b/tests/e2e/test_mobile.py
@@ -31,6 +31,7 @@ def _register(page: Page, base_url: str, email: str = None):
     page.goto(f"{base_url}/auth/register")
     page.fill('input[name="email"]', email)
     page.fill('input[name="password"]', password)
+    page.fill('input[name="confirm"]', password)
     invite_field = page.locator('input[name="invite_code"]')
     if invite_field.count() > 0 and invite_field.is_visible():
         invite_field.fill("BETA")


### PR DESCRIPTION
## Summary
- Fix E2E tests: fill `confirm` field (not `confirm_password` which doesn't exist)
- Fix `DurableWorkflow` forward reference: re-quote for Python 3.12 compat (UP037 auto-fix broke it since file lacks `from __future__ import annotations`)
- Revert Dockerfile to Python 3.12 (numba lacks Linux 3.14 wheels)

## Test plan
- [ ] E2E tests should pass (registration form now filled correctly)
- [ ] test-t2-nightly should pass (workflow_engine import fixed)
- [ ] Deploy should succeed with `--depot=false` workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)