### PR TITLE
Fix smoke test URL: pass $BASE_URL as arg instead of defaulting to aelu.app

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,6 @@ jobs:
           exit 1
 
       - name: Post-deploy smoke test
-        run: ./scripts/smoke_test.sh
+        run: ./scripts/smoke_test.sh "$BASE_URL"
         env:
           BASE_URL: https://aelu-app.fly.dev


### PR DESCRIPTION
## Summary

- The post-deploy smoke script reads its target URL from `$1` (positional argument), not from the `BASE_URL` environment variable
- CI was calling `./scripts/smoke_test.sh` with no arguments, so the script defaulted to `https://aelu.app` — a domain that doesn't resolve from CI runners
- Every deploy since at least 2026-03-27 returned HTTP `000` on all 14 checks (connection failure before any HTTP response)
- Fix: pass `"$BASE_URL"` as the first argument; the env var is already correctly set to `https://aelu-app.fly.dev`

## Change

```diff
-        run: ./scripts/smoke_test.sh
+        run: ./scripts/smoke_test.sh "$BASE_URL"
```

1 line. No application code changed. No test changes.

## Test plan

- [ ] Deploy workflow triggers on merge → smoke job calls `./scripts/smoke_test.sh "https://aelu-app.fly.dev"` → checks reach the live Fly app → all 14 checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)