### PR TITLE
Fix outage root cause (disk full), DR test failures, deprecated model

### DIFF
--- a/.github/workflows/dr-test.yml
+++ b/.github/workflows/dr-test.yml
@@ -17,7 +17,9 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Initialize test database
-        run: python -c "from mandarin.db import core; core.ensure_db()"
+        run: |
+          rm -f data/mandarin.db data/mandarin.db-shm data/mandarin.db-wal
+          python -c "from mandarin.db import core; core.ensure_db()"
         env:
           DATA_DIR: data
       - name: Run DR test

--- a/.github/workflows/dr-test.yml
+++ b/.github/workflows/dr-test.yml
@@ -13,11 +13,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+          cache: 'pip'
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Initialize test database
-        run: python -c "from mandarin.db import core; core.init_db()"
+        run: python -c "from mandarin.db import core; core.ensure_db()"
         env:
-          DATABASE_PATH: data/mandarin.db
+          DATA_DIR: data
       - name: Run DR test
         run: bash scripts/dr_test.sh

--- a/.github/workflows/health-monitor.yml
+++ b/.github/workflows/health-monitor.yml
@@ -43,7 +43,7 @@ jobs:
 
           if [ -n "$OPEN" ]; then
             echo "Incident issue #$OPEN already open — skipping"
-            gh issue comment "$OPEN" --body "Health check still failing at $(date -u +%H:%M). live=${{ steps.health.outputs.live }} ready=${{ steps.health.outputs.ready }}"
+            gh issue comment "$OPEN" --body "Health check still failing at $(date -u +%H:%M). live=${{ steps.health.outputs.live }} ready=${{ steps.health.outputs.ready }}" || true
           else
             gh issue create \
               --title "App is down (health check failed)" \
@@ -58,5 +58,7 @@ jobs:
           Fly.io should auto-restart the machine. If this keeps happening, there may be a code bug causing crashes — check Sentry for errors.
 
           This issue was created automatically by the health monitor." \
-              --label "incident"
+              --label "incident" || true
           fi
+          # Always fail the job when app is down — this is how GitHub sends the alert email
+          exit 1

--- a/BUILD_STATE.md
+++ b/BUILD_STATE.md
@@ -5,7 +5,7 @@
 **Date:** 2026-03-15
 **Content library:** HSK 1-9 canonical word lists (10,000+ items via `add-hsk`), context notes, 134 auto-tagged, 30 dialogue scenarios
 **Grammar/skills:** 26 grammar points (HSK 1-3), 14 language skills seeded
-**Schema:** V133 (86 tables, 6-stage mastery lifecycle, observability, security audit, MFA challenge, grade appeal, activation tracking, security scans, quality infrastructure, experiment proposals, graduated rollouts, openclaw scheduler)
+**Schema:** V134 (86 tables, 6-stage mastery lifecycle, observability, security audit, MFA challenge, grade appeal, activation tracking, security scans, quality infrastructure, experiment proposals, graduated rollouts, openclaw scheduler)
 **Tests:** 4061 passed, 2 skipped, 0 failed across 225 suites (~5m08s runtime)
 **Skips:** 2 E2E (Playwright not installed — requires browser binary, runs in separate CI job)
 **Warnings:** 48 (InsecureKeyLengthWarning from test JWT secrets — cosmetic, not blocking)
@@ -280,7 +280,7 @@
 
 ---
 
-## Schema (86 tables, V133)
+## Schema (86 tables, V134)
 
 | Table | Purpose |
 |---|---|
@@ -417,7 +417,7 @@ mandarin/
     └── templates/index.html
 mobile/                  # Capacitor shell (iOS/Android)
 run                      # Bash launcher (./run, ./run menu, ./run app, ./run help)
-schema.sql               # Full schema (86 tables, V133)
+schema.sql               # Full schema (86 tables, V134)
 learner_profile.json     # Persona configuration
 tests/                       # 4061 tests across 225 suites
 data/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,7 @@
 # Security Policy
 
 **Platform:** Aelu Learning System
-**Version:** V2 (Schema V133)
+**Version:** V2 (Schema V134)
 **Last reviewed:** 2026-02-22
 **Owner:** Jason Gerson
 **Classification:** Internal / Compliance Reference

--- a/fly.toml
+++ b/fly.toml
@@ -24,10 +24,10 @@ primary_region = "ewr"
   processes = ["app"]
 
   [[http_service.checks]]
-    grace_period = "10s"
+    grace_period = "30s"
     interval = "15s"
     method = "GET"
-    path = "/api/health/ready"
+    path = "/api/health/live"
     timeout = "5s"
 
 [[vm]]

--- a/mandarin/ai/model_selector.py
+++ b/mandarin/ai/model_selector.py
@@ -90,7 +90,6 @@ _CLOUD_OSS_MODELS = [
     # Together AI — widest model selection
     {"name": "together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo", "provider": "together", "size_b": 70.0},
     {"name": "together_ai/meta-llama/Llama-3.1-8B-Instruct-Turbo", "provider": "together", "size_b": 8.0},
-    {"name": "together_ai/mistralai/Mixtral-8x7B-Instruct-v0.1", "provider": "together", "size_b": 47.0},
     {"name": "together_ai/Qwen/Qwen2.5-72B-Instruct", "provider": "together", "size_b": 72.0},
     {"name": "together_ai/Qwen/Qwen2.5-7B-Instruct", "provider": "together", "size_b": 7.0},
     {"name": "together_ai/deepseek-ai/DeepSeek-V3", "provider": "together", "size_b": 671.0},

--- a/mandarin/counter_metrics.py
+++ b/mandarin/counter_metrics.py
@@ -1946,3 +1946,12 @@ def get_snapshot_history(conn: sqlite3.Connection,
     """, (user_id, limit)).fetchall()
 
     return [dict(r) for r in rows]
+
+
+def measure_delayed_recall(conn: sqlite3.Connection, user_id: int = 1) -> int:
+    """Identify and record delayed-recall measurements for 24h+ samples.
+
+    Placeholder: no dedicated delayed-recall sample queue exists yet.
+    Returns 0 until the sampling infrastructure is built out.
+    """
+    return 0

--- a/mandarin/db/core.py
+++ b/mandarin/db/core.py
@@ -7911,10 +7911,16 @@ def _migrate_v133_to_v134(conn: sqlite3.Connection) -> None:
         "lens_satire": 0.7,
         "lens_moral_texture": 0.7,
     }
+    # Use unconditional COALESCE rather than WHERE col IS NULL.
+    # Columns added via ALTER TABLE ADD COLUMN have no physical storage for
+    # existing rows; SQLite returns the DEFAULT for reads, so "IS NULL" never
+    # matches them — but PRAGMA integrity_check still flags the absent bytes as
+    # a NOT NULL violation.  COALESCE forces a physical write while preserving
+    # any real user-set values.
     for col, default in lens_defaults.items():
         if col in cols:
             conn.execute(
-                f"UPDATE learner_profile SET {col} = ? WHERE {col} IS NULL",
+                f"UPDATE learner_profile SET {col} = COALESCE({col}, ?)",
                 (default,),
             )
     conn.commit()

--- a/mandarin/db/core.py
+++ b/mandarin/db/core.py
@@ -135,7 +135,7 @@ def get_pool_stats() -> dict:
     }
 
 
-SCHEMA_VERSION = 133  # Increment when adding migrations
+SCHEMA_VERSION = 134  # Increment when adding migrations
 
 
 def _get_schema_version(conn: sqlite3.Connection) -> int:
@@ -7886,6 +7886,40 @@ def _migrate_v132_to_v133(conn):
     conn.commit()
 
 
+def _migrate_v133_to_v134(conn: sqlite3.Connection) -> None:
+    """v133->v134: Fix NULL NOT-NULL lens columns from ALTER TABLE ADD COLUMN migrations.
+
+    SQLite 3.37+ integrity_check flags NOT NULL violations in physical storage for
+    columns added via ALTER TABLE ADD COLUMN on existing rows. The bootstrap learner
+    profile row may have NULL stored for these lens columns even though the schema
+    records a DEFAULT. This migration back-fills them to their intended defaults.
+    """
+    cols = _col_set(conn, "learner_profile")
+    lens_defaults = {
+        "lens_quiet_observation": 0.7,
+        "lens_institutions": 0.7,
+        "lens_urban_texture": 0.7,
+        "lens_humane_mystery": 0.7,
+        "lens_identity": 0.7,
+        "lens_comedy": 0.7,
+        "lens_food": 0.5,
+        "lens_travel": 0.5,
+        "lens_explainers": 0.5,
+        "lens_wit": 0.7,
+        "lens_ensemble_comedy": 0.7,
+        "lens_sharp_observation": 0.7,
+        "lens_satire": 0.7,
+        "lens_moral_texture": 0.7,
+    }
+    for col, default in lens_defaults.items():
+        if col in cols:
+            conn.execute(
+                f"UPDATE learner_profile SET {col} = ? WHERE {col} IS NULL",
+                (default,),
+            )
+    conn.commit()
+
+
 MIGRATIONS = {
     0: _migrate_v0_to_v1,
     1: _migrate_v1_to_v2,
@@ -8020,6 +8054,7 @@ MIGRATIONS = {
     130: _migrate_v130_to_v131,
     131: _migrate_v131_to_v132,
     132: _migrate_v132_to_v133,
+    133: _migrate_v133_to_v134,
 }
 
 

--- a/mandarin/web/nightly_intelligence_scheduler.py
+++ b/mandarin/web/nightly_intelligence_scheduler.py
@@ -77,15 +77,25 @@ def _run_loop():
             conn = db.get_connection()
             try:
                 if acquire_lock(conn, "nightly_intelligence", ttl_seconds=3600):
-                    _intelligence_tick(conn)
-                    release_lock(conn, "nightly_intelligence")
-                    # Log so we don't catch up again
-                    conn.execute("""
-                        INSERT INTO openclaw_message_log
-                        (agent_type, direction, message_text, user_id)
-                        VALUES ('nightly_intelligence', 'outbound', 'catch-up digest sent', 1)
-                    """)
-                    conn.commit()
+                    try:
+                        _intelligence_tick(conn)
+                    except Exception:
+                        logger.exception("Nightly intelligence catch-up tick failed")
+                    finally:
+                        release_lock(conn, "nightly_intelligence")
+                        # Always log the attempt so restarts don't re-trigger catch-up
+                        try:
+                            conn.execute("""
+                                INSERT INTO openclaw_message_log
+                                (agent_type, direction, message_text, user_id)
+                                VALUES ('nightly_intelligence', 'outbound',
+                                        'catch-up digest attempted', 1)
+                            """)
+                            conn.commit()
+                        except Exception:
+                            logger.debug(
+                                "Could not log catch-up attempt", exc_info=True
+                            )
             except Exception:
                 logger.exception("Nightly intelligence catch-up failed")
             finally:

--- a/mandarin/web/routes.py
+++ b/mandarin/web/routes.py
@@ -211,27 +211,41 @@ def register_routes(app):
 
     @app.route("/api/health/ready")
     def api_health_ready():
-        """Readiness probe — DB writable, schema current."""
+        """Readiness probe — DB readable, schema current.
+
+        Uses a disposable connection with a short busy_timeout so the probe
+        returns quickly (200 or 503) instead of hanging for 15 s when the WAL
+        is being checkpointed or background writers hold locks.
+        """
         import time as _time
         t0 = _time.monotonic()
+        conn = None
         try:
-            with db.connection() as conn:
-                conn.execute("SELECT 1")
-                from ..db.core import _get_schema_version, SCHEMA_VERSION
-                schema_version = _get_schema_version(conn)
-                if schema_version < SCHEMA_VERSION:
-                    elapsed_ms = round((_time.monotonic() - t0) * 1000, 1)
-                    return jsonify({
-                        "status": "not_ready",
-                        "reason": f"schema migration pending: v{schema_version} → v{SCHEMA_VERSION}",
-                        "latency_ms": elapsed_ms,
-                    }), 503
-                elapsed_ms = round((_time.monotonic() - t0) * 1000, 1)
-                return jsonify({"status": "ok", "latency_ms": elapsed_ms})
+            conn = db.get_connection()
+            # Override to a 2-second timeout: fail fast and honest rather than
+            # hanging through the full 15 s default.
+            conn.execute("PRAGMA busy_timeout=2000")
+            conn.execute("SELECT 1")
+            from ..db.core import _get_schema_version, SCHEMA_VERSION
+            schema_version = _get_schema_version(conn)
+            elapsed_ms = round((_time.monotonic() - t0) * 1000, 1)
+            if schema_version < SCHEMA_VERSION:
+                return jsonify({
+                    "status": "not_ready",
+                    "reason": f"schema migration pending: v{schema_version} → v{SCHEMA_VERSION}",
+                    "latency_ms": elapsed_ms,
+                }), 503
+            return jsonify({"status": "ok", "latency_ms": elapsed_ms})
         except (sqlite3.Error, OSError) as e:
             elapsed_ms = round((_time.monotonic() - t0) * 1000, 1)
             logger.error("readiness check failed: %s", e)
             return jsonify({"status": "not_ready", "reason": _sanitize_error(e), "latency_ms": elapsed_ms}), 503
+        finally:
+            if conn:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
 
     @app.route("/api/health")
     def api_health():

--- a/schema.sql
+++ b/schema.sql
@@ -1218,7 +1218,13 @@ CREATE TABLE IF NOT EXISTS lti_user_mapping (
 -- ────────────────────────────────
 INSERT OR IGNORE INTO user (id, email, password_hash, display_name, subscription_tier, is_active)
     VALUES (1, 'local@localhost', 'bootstrap_no_login', 'Local', 'free', 0);
-INSERT OR IGNORE INTO learner_profile (id, user_id) VALUES (1, 1);
+INSERT OR IGNORE INTO learner_profile (
+    id, user_id,
+    lens_quiet_observation, lens_institutions, lens_urban_texture,
+    lens_humane_mystery, lens_identity, lens_comedy, lens_food,
+    lens_travel, lens_explainers, lens_wit, lens_ensemble_comedy,
+    lens_sharp_observation, lens_satire, lens_moral_texture
+) VALUES (1, 1, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.5, 0.5, 0.5, 0.7, 0.7, 0.7, 0.7, 0.7);
 
 -- ────────────────────────────────
 -- QUALITY INFRASTRUCTURE (V42+)


### PR DESCRIPTION
## Summary

### Root causes fixed

**Recurring outages (02:53, 04:33 Apr 17; 16:03 Apr 17; 05:53, 10:25 Apr 18)**
- Primary: `/api/health/ready` was taking 7–15 s under WAL checkpoint contention (busy_timeout=15 s on a pooled connection). Fly.io's 5 s health check timeout marked the machine unhealthy → Connection Timeout for all traffic.
- Secondary (already applied live): 1 GB volume was 100% full from 462 MB WAL + 444 MB Litestream shadow. Volume extended to 3 GB via \`fly volumes extend\` (no restart needed).

**DR test (3 Sundays of failures)**
- Wrong env var (\`DATABASE_PATH\` → \`DATA_DIR\`), \`init_db()\` instead of \`ensure_db()\`, committed \`data/mandarin.db\` with user_version=0 bypasses migrations, Ubuntu SQLite 3.45 flags physical NULLs in ALTER TABLE ADD COLUMN columns as integrity violations.

**Production ImportError (Sentry, 03:00 UTC)**
- \`measure_delayed_recall\` imported in nightly scheduler but never implemented — fixed with a safe stub.

**doc-check**
- BUILD_STATE.md and SECURITY.md referenced V133 after schema bump to V134.

---

## Changes

| File | What changed |
|---|---|
| \`fly.toml\` | Health check path \`/api/health/ready\` → \`/api/health/live\` (no DB I/O); grace_period 10s → 30s |
| \`mandarin/web/routes.py\` | \`/api/health/ready\` uses a fresh disposable connection with busy_timeout=2000 ms — fails fast (503) instead of hanging 15 s |
| \`.github/workflows/health-monitor.yml\` | \`|| true\` on issue create/comment; explicit \`exit 1\` when app is down; incident label fixed |
| \`.github/workflows/dr-test.yml\` | Delete committed DB before \`ensure_db()\`; \`DATA_DIR\` env var; pip cache |
| \`mandarin/db/core.py\` | Migration v133→v134: COALESCE instead of WHERE IS NULL (ALTER TABLE columns not physically stored); SCHEMA_VERSION=134 |
| \`mandarin/counter_metrics.py\` | Add \`measure_delayed_recall()\` stub to fix ImportError |
| \`schema.sql\` | Explicit lens column values in bootstrap INSERT |
| \`mandarin/web/nightly_intelligence_scheduler.py\` | \`release_lock\` + log INSERT in \`finally\` block |
| \`mandarin/ai/model_selector.py\` | Remove deprecated Together AI Mixtral-8x7B |
| \`BUILD_STATE.md\`, \`SECURITY.md\` | V133 → V134 |

---

> ⚠️ **Litestream S3 credentials are also broken** — \`InvalidAccessKeyId\` every 2 s in Fly logs. Off-site backups haven't been working. Needs \`fly secrets set AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...\` with fresh IAM credentials.

## Test plan

- [ ] Verify DR test passes: \`gh workflow run dr-test.yml --ref claude/ecstatic-neumann\`
- [ ] Monitor Fly.io health checks — should stay green with liveness probe
- [ ] Rotate Litestream AWS credentials: \`fly secrets set AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...\`
- [ ] Confirm no Connection Timeout outages after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)