### PR TITLE
Fix CI failures, OOM crashes, and lint

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -44,4 +44,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
-        run: python scripts/auto_fix_ci.py
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "ANTHROPIC_API_KEY secret not set — skipping auto-fix agent"
+            echo "Set it via: gh secret set ANTHROPIC_API_KEY --repo AeluApp/mandarin"
+            exit 0
+          fi
+          python scripts/auto_fix_ci.py

--- a/.github/workflows/dr-test.yml
+++ b/.github/workflows/dr-test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Initialize test database
-        run: python -c "from mandarin.db import core; core.init_db()"
+        run: python -c "from mandarin.db import core; conn = core.init_db(); core._migrate(conn)"
         env:
           DATABASE_PATH: data/mandarin.db
       - name: Run DR test

--- a/.github/workflows/health-monitor.yml
+++ b/.github/workflows/health-monitor.yml
@@ -16,6 +16,8 @@ jobs:
       actions: write
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Check production health
         id: health
         run: |

--- a/mandarin/ai/genai_layer.py
+++ b/mandarin/ai/genai_layer.py
@@ -705,13 +705,13 @@ def detect_prompt_regressions(conn) -> list[dict]:
 # Module 5: Local Embedding Layer
 # ═══════════════════════════════════════════════════════════════════════════════
 
-_EMBEDDING_MODEL_NAME = "paraphrase-multilingual-mpnet-base-v2"
+_EMBEDDING_MODEL_NAME = "sentence-transformers/paraphrase-multilingual-mpnet-base-v2"
 _embedding_model = None
 _embedding_lock = None
 
 
 def _get_multilingual_model():
-    """Thread-safe singleton for multilingual embedding model.
+    """Thread-safe singleton for multilingual embedding model (ONNX via fastembed).
 
     Separate from fuzzy_dedup.py's all-MiniLM-L6-v2.
     """
@@ -722,8 +722,8 @@ def _get_multilingual_model():
     if _embedding_model is None:
         with _embedding_lock:
             if _embedding_model is None:
-                from sentence_transformers import SentenceTransformer
-                _embedding_model = SentenceTransformer(_EMBEDDING_MODEL_NAME)
+                from fastembed import TextEmbedding
+                _embedding_model = TextEmbedding(_EMBEDDING_MODEL_NAME)
     return _embedding_model
 
 
@@ -734,7 +734,7 @@ def compute_item_embeddings(conn, content_item_ids: list[int] | None = None,
         import numpy as np
         model = _get_multilingual_model()
     except ImportError:
-        return {"status": "skipped", "reason": "sentence-transformers not installed"}
+        return {"status": "skipped", "reason": "fastembed not installed"}
 
     # --- Determine which items need embeddings ---
     # Try LanceDB first to check what's already embedded
@@ -800,7 +800,7 @@ def compute_item_embeddings(conn, content_item_ids: list[int] | None = None,
         return {"status": "complete", "computed": 0}
 
     texts = [f"{r['hanzi']} {r['pinyin']} {r['english']}" for r in rows]
-    embeddings = model.encode(texts, show_progress_bar=False)
+    embeddings = np.array(list(model.embed(texts)))
 
     # --- Write to LanceDB (primary) ---
     if lance_db is not None:
@@ -854,7 +854,7 @@ def find_similar_items(conn, query_hanzi: str, top_k: int = 5) -> list[dict]:
     except ImportError:
         return []
 
-    query_emb = model.encode([query_hanzi], show_progress_bar=False)[0]
+    query_emb = next(model.embed([query_hanzi]))
 
     # --- Try LanceDB (primary) ---
     lance_db = _get_lance_db()

--- a/mandarin/db/core.py
+++ b/mandarin/db/core.py
@@ -135,7 +135,7 @@ def get_pool_stats() -> dict:
     }
 
 
-SCHEMA_VERSION = 133  # Increment when adding migrations
+SCHEMA_VERSION = 134  # Increment when adding migrations
 
 
 def _get_schema_version(conn: sqlite3.Connection) -> int:
@@ -7886,6 +7886,29 @@ def _migrate_v132_to_v133(conn):
     conn.commit()
 
 
+def _migrate_v133_to_v134(conn: sqlite3.Connection) -> None:
+    """v133->v134: Backfill NULL lens_* columns in learner_profile.
+
+    ALTER TABLE ADD COLUMN stores defaults lazily in SQLite; SQLite 3.45+
+    PRAGMA integrity_check flags those physical NULLs as NOT NULL violations.
+    This migration physically writes the default (0.7) for any row that has
+    a NULL in one of the personality lens columns added in v37→v38.
+    """
+    logger.info("Migration v133→v134: backfill NULL lens_* columns in learner_profile")
+    lens_cols = (
+        "lens_wit",
+        "lens_ensemble_comedy",
+        "lens_sharp_observation",
+        "lens_satire",
+        "lens_moral_texture",
+    )
+    cols = _col_set(conn, "learner_profile")
+    for col in lens_cols:
+        if col in cols:
+            conn.execute(f"UPDATE learner_profile SET {col} = 0.7 WHERE {col} IS NULL")
+    conn.commit()
+
+
 MIGRATIONS = {
     0: _migrate_v0_to_v1,
     1: _migrate_v1_to_v2,
@@ -8020,6 +8043,7 @@ MIGRATIONS = {
     130: _migrate_v130_to_v131,
     131: _migrate_v131_to_v132,
     132: _migrate_v132_to_v133,
+    133: _migrate_v133_to_v134,
 }
 
 

--- a/mandarin/ml/fuzzy_dedup.py
+++ b/mandarin/ml/fuzzy_dedup.py
@@ -27,10 +27,10 @@ def _get_model():
         with _model_lock:
             if _model is None:
                 try:
-                    from sentence_transformers import SentenceTransformer
-                    _model = SentenceTransformer('all-MiniLM-L6-v2')
+                    from fastembed import TextEmbedding
+                    _model = TextEmbedding('sentence-transformers/all-MiniLM-L6-v2')
                 except ImportError:
-                    logger.warning("sentence-transformers not installed; fuzzy dedup unavailable")
+                    logger.warning("fastembed not installed; fuzzy dedup unavailable")
                     return None
                 except Exception as e:
                     logger.warning("Failed to load sentence transformer: %s", e)
@@ -49,7 +49,7 @@ def compute_similarity(text_a: str, text_b: str) -> float:
     if model is None:
         return 0.0
 
-    embeddings = model.encode([text_a, text_b], convert_to_numpy=True)
+    embeddings = np.array(list(model.embed([text_a, text_b])))
     norm_a = np.linalg.norm(embeddings[0])
     norm_b = np.linalg.norm(embeddings[1])
     if norm_a == 0 or norm_b == 0:
@@ -88,7 +88,7 @@ def find_semantic_duplicate(
     # Batch encode all titles at once
     existing_titles = [r['title'] for r in existing]
     all_texts = [title] + existing_titles
-    embeddings = model.encode(all_texts, convert_to_numpy=True, show_progress_bar=False)
+    embeddings = np.array(list(model.embed(all_texts)))
 
     new_emb = embeddings[0]
     new_norm = np.linalg.norm(new_emb)
@@ -148,7 +148,7 @@ def find_content_duplicate(
     candidate_texts = [f"{c['hanzi']} {c['english']}" for c in candidates]
 
     all_texts = [new_text] + candidate_texts
-    embeddings = model.encode(all_texts, convert_to_numpy=True, show_progress_bar=False)
+    embeddings = np.array(list(model.embed(all_texts)))
 
     new_emb = embeddings[0]
     new_norm = np.linalg.norm(new_emb)
@@ -184,7 +184,7 @@ def cache_embedding(conn: sqlite3.Connection, finding_id: int, title: str) -> No
     if model is None:
         return
     try:
-        embedding = model.encode([title], convert_to_numpy=True)[0]
+        embedding = next(model.embed([title]))
         embedding_bytes = embedding.tobytes()
         conn.execute("""
             INSERT OR REPLACE INTO pi_finding_embeddings
@@ -220,7 +220,7 @@ def calibrate_similarity_threshold(conn: sqlite3.Connection) -> dict:
             continue
 
         titles = [f['title'] for f in dim_findings]
-        embeddings = model.encode(titles, convert_to_numpy=True, show_progress_bar=False)
+        embeddings = np.array(list(model.embed(titles)))
 
         for i in range(len(dim_findings)):
             for j in range(i + 1, len(dim_findings)):

--- a/mandarin/quality/retention.py
+++ b/mandarin/quality/retention.py
@@ -705,7 +705,7 @@ def get_retention_summary(conn) -> dict[str, float]:
         time_pts = km.get("time_points", [])
         for target_day in (1, 7, 30):
             rate = None
-            for t, s in zip(time_pts, survival):
+            for t, s in zip(time_pts, survival, strict=False):
                 if t >= target_day:
                     rate = s
                     break

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ audio = [
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
+    "pytest-timeout>=2.3.0",
     "pytest-xdist>=3.0.0",
     "hypothesis>=6.0.0",
     "pydantic>=2.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ jieba>=0.42.1
 httpx>=0.27.0,<1.0
 scikit-learn>=1.4.0,<2.0
 lightgbm>=4.0.0,<5.0
-sentence-transformers>=2.2.0,<6.0
+fastembed>=0.3.0,<1.0
 joblib>=1.3.0,<2.0
 zope.interface==8.0.1
 instructor>=1.0.0,<2.0


### PR DESCRIPTION
## Summary

- **Health Monitor**: was failing every 5 min because `gh` CLI requires a git checkout to resolve repo context — added `actions/checkout@v4`
- **DR Test**: SQLite 3.45+ now checks NOT NULL constraints in `PRAGMA integrity_check`; rows in `learner_profile` had physically-null storage for `lens_wit/lens_ensemble_comedy/lens_sharp_observation/lens_satire/lens_moral_texture` from the v37→v38 `ALTER TABLE ADD COLUMN` migration (lazy default storage). Added migration v133→v134 to backfill these with 0.7. CI workflow now calls `_migrate()` after `init_db()` so the fix applies to fresh test DBs too.
- **OOM / app down**: replaced `sentence-transformers` with `fastembed`. sentence-transformers pulls in PyTorch (~500MB) + `paraphrase-multilingual-mpnet-base-v2` (~600MB in memory), pushing the process past the 2GB Fly.io machine limit. fastembed uses onnxruntime instead — same models, same vector dimensions (backward-compatible with stored embeddings), ~800MB less memory. Expected to bring the process from >2GB to ~500MB.
- **Deploy**: `--timeout=300` in the pytest invocation was failing because `pytest-timeout` wasn't in dev dependencies — added it.
- **Auto-Fix**: was hard-failing when `ANTHROPIC_API_KEY` secret isn't set — changed to a graceful skip with setup instructions. To enable: `gh secret set ANTHROPIC_API_KEY --repo AeluApp/mandarin`
- **Lint**: ruff B905 — missing `strict=` on `zip()` in `retention.py`

## Test plan

- [ ] Deploy merges and CI passes (test, lint, quality-gates)
- [ ] Health Monitor workflow goes green (app needs to be up first — the OOM fix should help)
- [ ] DR Test passes next Sunday
- [ ] Monitor Sentry for OOM kills after deploy — should drop to zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)