### PR TITLE
Fix remaining encode→embed migrations for fastembed (rag_evaluation, rag_layer)

### DIFF
--- a/mandarin/ai/rag_evaluation.py
+++ b/mandarin/ai/rag_evaluation.py
@@ -81,8 +81,7 @@ def build_faiss_index(
         return {"status": "error", "reason": "no texts to index"}
 
     # Encode
-    embeddings = model.encode(texts, show_progress_bar=False, batch_size=64)
-    embeddings = np.array(embeddings, dtype=np.float32)
+    embeddings = np.array(list(model.embed(texts)), dtype=np.float32)
     dimension = embeddings.shape[1]
 
     # Normalize for cosine similarity
@@ -234,8 +233,7 @@ def _faiss_retrieve(
         return []
 
     # Encode query
-    query_vec = model.encode([query], show_progress_bar=False)
-    query_vec = np.array(query_vec, dtype=np.float32)
+    query_vec = np.array(list(model.embed([query])), dtype=np.float32)
     faiss.normalize_L2(query_vec)
 
     # Search
@@ -303,12 +301,12 @@ def evaluate_retrieval(
     # Relevance: embedding similarity between query and retrieved docs
     model = _get_multilingual_model()
     if model and retrieved_docs:
-        query_emb = model.encode([query], show_progress_bar=False)
+        query_emb = np.array(list(model.embed([query])))
         doc_texts = [
             f"{d.get('hanzi', '')} {d.get('english', '')} {d.get('pinyin', '')}"
             for d in retrieved_docs
         ]
-        doc_embs = model.encode(doc_texts, show_progress_bar=False)
+        doc_embs = np.array(list(model.embed(doc_texts)))
 
         if _HAS_NUMPY:
             q = np.array(query_emb)

--- a/mandarin/ai/rag_layer.py
+++ b/mandarin/ai/rag_layer.py
@@ -242,7 +242,7 @@ def retrieve_context_for_generation(
                 model = _get_multilingual_model()
                 # Build a query from the missing hanzi
                 query_text = " ".join(missing)
-                query_emb = model.encode([query_text], show_progress_bar=False)[0].tolist()
+                query_emb = next(model.embed([query_text])).tolist()
                 vector_results = table.search(query_emb).limit(3).to_pandas()
 
                 found_ids = {item["hanzi"] for item in found}

--- a/tests/test_genai_layer.py
+++ b/tests/test_genai_layer.py
@@ -271,12 +271,11 @@ class TestEmbeddingLayer(unittest.TestCase):
         _seed_items(conn, count=3)
         mock_model = MagicMock()
         embeddings = np.random.rand(3, 768).astype(np.float32)
-        mock_model.embed.return_value = embeddings
+        # embed() is called as an iterator; use side_effect for fresh iter each call
+        mock_model.embed.side_effect = lambda texts: iter(embeddings[:len(texts)])
         with patch("mandarin.ai.genai_layer._get_multilingual_model", return_value=mock_model), \
              patch("mandarin.ai.genai_layer._get_lance_db", return_value=None):
             compute_item_embeddings(conn, content_item_ids=[1, 2, 3])
-            # For query, return single embedding
-            mock_model.embed.return_value = embeddings[:1]
             results = find_similar_items(conn, "字1")
         self.assertGreater(len(results), 0)
         self.assertIn("similarity", results[0])


### PR DESCRIPTION
## Summary

Completes the sentence-transformers → fastembed migration started in PR #59. Three files still called `.encode()` on the embedding model:

- **`rag_evaluation.py`**: 4 call sites updated (`model.encode(texts)` → `np.array(list(model.embed(texts)))`)
- **`rag_layer.py`**: `model.encode([q])[0]` → `next(model.embed([q]))`  
- **`test_genai_layer.py`**: `test_find_similar_items_with_data` — updated mock to use `side_effect` returning fresh iterators so both `list(model.embed(batch))` and `next(model.embed([query]))` work correctly

## Root cause

PR #59 migrated `genai_layer.py` and `fuzzy_dedup.py` but missed `rag_evaluation.py` and `rag_layer.py`. The test failure was revealed by `_HAS_EMBEDDING_MODEL` resolving to True (fastembed installed) which ran the previously-skipped `test_evaluation_logged`.

## Test plan
- [ ] `Tests / test (3.12)` passes (both genai_layer and rag_evaluation tests)
- [ ] `Deploy / test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)